### PR TITLE
Fix regex error on form validation

### DIFF
--- a/client/components/partials/design/Form.js
+++ b/client/components/partials/design/Form.js
@@ -10,7 +10,7 @@ const validate = values => {
   } else if (values.appName.length > 15) {
     errors.appName = 'Must be 15 characters or less';
   }
-  if (!/^[\s*\d{1,4}\s*]?$/.test(values.port)) {
+  if (!/^\d{1,4}\s*$/.test(values.port) && values.port !== '') {
     errors.port = 'Port must be an integer between 0 and 9999';
   } else if (values.port.length > 5) {
     errors.port = 'Must be 5 characters or less';

--- a/client/components/partials/design/Sidebar.js
+++ b/client/components/partials/design/Sidebar.js
@@ -51,8 +51,6 @@ class Sidebar extends React.Component {
 }
 
 Sidebar.propTypes = {
-  updateConfig: React.PropTypes.func,
-  serverConfig: React.PropTypes.object,
 };
 
 export default Sidebar;


### PR DESCRIPTION
# Proposed changes
## Description

Fixed the form validation
## Issue

The validation for the port number was incorrect. It would error on correct values.
### Fixes

Changed the regex that validates the port input. It  should be a number 0-4 digits long
## files changed:
- client/components/partials/design/Form.js
