### PR TITLE
Add strings to main server file that require and use the routers

### DIFF
--- a/client/components/partials/design/Form.js
+++ b/client/components/partials/design/Form.js
@@ -49,7 +49,7 @@ class Form extends React.Component {
           expressName: formData.expressName,
           appName: formData.appName,
         },
-        routes: this.props.routers,
+        routers: this.props.routers,
       },
     };
 

--- a/server/src/controllers/expressBuild/buildMainFile.js
+++ b/server/src/controllers/expressBuild/buildMainFile.js
@@ -1,20 +1,52 @@
 // include middleware
 
+// { id: 'df068b36-99c0-4dc8-83a2-9726ba048958',
+//     startPoint: '/endpoint',
+//     endpoints: [],
+//     editingStartPoint: false,
+//     editingName: false,
+//     name: 'New router' }
+
+// helper function
+import { camelize } from '../../utils/utils.js';
+
+// function camelize(str) {
+//   return str.replace(/(?:^\w|[A-Z]|\b\w)/g, function(letter, index) {
+//     return index == 0 ? letter.toLowerCase() : letter.toUpperCase();
+//   }).replace(/\s+/g, '');
+// }
+
+/* -------------------------- */
+
 function addExpress(expressName) {
-  return `var ${expressName} = require (\'express\');\n`;
+  return `var ${expressName} = require (\'express\');\n\n`;
 }
 
 // use imported middleware
 function requireRouters(routers) {
   let fileString = '';
   routers.forEach(router => {
-    fileString += `var ${router.name} = require('./{router.name}');`;
+    const name = camelize(router.name);
+    fileString += `var ${name} = require('./${name}');\n\n`;
+  });
+  return fileString;
+}
+
+// var routes = require('./routes/index');
+// var users = require('./routes/users');
+// app.use('/', routes);
+// app.use('/users', users);
+function useRouters(routers) {
+  let fileString = '';
+  routers.forEach(router => {
+    const name = camelize(router.name);
+    fileString += `app.use(\'${router.startPoint}\', ${name});\n\n`;
   });
   return fileString;
 }
 
 function addServerListen(name, port) {
-  return `app.listen(${port}, function () {console.log(\'${name} listening on port ${port}\');`;
+  return `app.listen(${port}, function () {console.log(\'${name} listening on port ${port}\');\n`;
 }
 
 export function buildMainFile(fileConfig, userConfig) {
@@ -27,6 +59,8 @@ export function buildMainFile(fileConfig, userConfig) {
   file += addExpress(expressName);
   // require router files
   file += requireRouters(routers);
+  // use routers as middleware
+  file += useRouters(routers);
   // server listen
   file += addServerListen(name, port);
   return file;

--- a/server/src/controllers/generateServer.js
+++ b/server/src/controllers/generateServer.js
@@ -17,7 +17,7 @@ export function generateExpressServer(request, response) {
 }
 
 export function generateServer(request, response) {
-  const reqData = request.body;
+  const reqData = request.body.data;
   if (reqData && reqData.serverType && reqData.serverType === 'express') {
     // generate express server
     return generateExpressServer(request, response);

--- a/server/src/utils/utils.js
+++ b/server/src/utils/utils.js
@@ -1,0 +1,5 @@
+export function camelize(str) {
+  return str.replace(/(?:^\w|[A-Z]|\b\w)/g, function(letter, index) {
+    return index == 0 ? letter.toLowerCase() : letter.toUpperCase();
+  }).replace(/\s+/g, '');
+}

--- a/test/server/controllers/expressBuild/buildFileTest.js
+++ b/test/server/controllers/expressBuild/buildFileTest.js
@@ -43,7 +43,9 @@ describe('File Builder', () => {
   describe('Build All files', () => {
     it('should build all files and save them to an array', () => {
       const response = httpMocks.createResponse();
-      expect(buildAllFiles(request, response)).to.contain('var app = require (\'express\');\napp.listen(8000, function () {console.log(\'myApp listening on port 8000\');');
+      console.log(buildAllFiles(request, response));
+
+      expect(buildAllFiles(request, response)).to.contain('var app = require (\'express\');\n\napp.listen(8000, function () {console.log(\'myApp listening on port 8000\');\n');
     });
   });
   it('should call not return an error when building the main server file', () => {


### PR DESCRIPTION
# Proposed changes
## Description

BuildMainFile adds the appropriate lines to require and use the router files

Added a utils.js file for helper functions. This file contains camelize(str) that converts any string to camelcase and deletes spaces.
## Issue

1.) The request JSON data used 'routes' as a key. 
2.) One of the server generating functions (sendToGithub?) used the wrong parameter
### Fixes
1. Change request JSON to 'routers' for consistency. 
2. Changed the parameter to request.body.data instead of request.body
## files changed:
- client/components/partials/design/Form.js
- server/src/controllers/expressBuild/buildMainFile.js
- server/src/controllers/generateServer.js
## files added:
- server/src/utils/*
