### PR TITLE
Implement custom scrollbar for canvas

### DIFF
--- a/client/styles/style.css
+++ b/client/styles/style.css
@@ -95,6 +95,19 @@ hr {
   white-space: nowrap;
 }
 
+.serverCanvas::-webkit-scrollbar {
+    height: 12px;
+}
+
+.serverCanvas::-webkit-scrollbar-track {
+    background: #1069a0;
+}
+ 
+.serverCanvas::-webkit-scrollbar-thumb {
+    border-radius: 10px;
+    background: #6fc6fc;
+}
+
 .endpointsContainer {
   margin: 10px 0;
 }


### PR DESCRIPTION
# Proposed changes
## Description

This adds a custom scrollbar for Webkit browsers in the server canvas area. This makes it both consistent with our styling and helps for the UX since some OS will hide scrollbars by default. This made our server section kinda weird looking when it went off screen. 
## Issue

Hidden scrollbars. 
### Fixes

Using `--webkit` flags we can target the browsers that are most likely to have this issue, e.g. Chrome and Safari on OSX systems.
## files changed:
- style.css
