### PR TITLE
fix bug in overwrite alert prompt and balance parenthesis in controller

### DIFF
--- a/client/components/partials/design/Form.js
+++ b/client/components/partials/design/Form.js
@@ -188,7 +188,7 @@ export default class Form extends React.Component {
       method: 'GET',
       credentials: 'same-origin',
     }).then(res => res.json()).then(user => {
-      if (Boolean(findWhere(user, formData.configName))) {
+      if (Boolean(findWhere(user, { appName: formData.configName }))) {
         swal({
           title: 'Warning: Configuration exists',
           text: 'Click continue to overwrite',

--- a/server/src/controllers/configController.js
+++ b/server/src/controllers/configController.js
@@ -22,7 +22,7 @@ export function createOne(request, response) {
 }
 
 export function getConfigs(request, response) {
-  Config.find({ user: request.cookies.user }, (err, configs) => {
+  Config.find(({ user: request.cookies.user }), (err, configs) => {
     if (err) {
       return response.status(404).json(err);
     }
@@ -39,3 +39,4 @@ export function deleteConfig(request, response) {
     return getConfigs(request, response);
   });
 }
+


### PR DESCRIPTION
# Proposed changes
## Description

When the save button is clicked, the user will either get a notification that the configuration is saved or prompted to overwrite an existing configuration. There was a bug that caused the user to always get a prompt to overwrite. 
